### PR TITLE
Improved Safari support

### DIFF
--- a/source/ts/index.ts
+++ b/source/ts/index.ts
@@ -102,7 +102,17 @@ const allCss = Array.from(document.styleSheets)
   )
   .flat();
 function getMatchedCSSRules(element: HTMLElement): Set<CSSStyleRule> {
-  return new Set(allCss.filter(rule => element.matches(rule.selectorText)));
+  return new Set(
+    allCss.filter(rule => {
+      try {
+        return element.matches(rule.selectorText);
+      } catch {
+        /* Sometimes Safari can get scared of its own rule declarations,    *
+         * so we should just treat those (and other errors) as non-matching */
+        return false;
+      }
+    })
+  );
 }
 
 function getStyleDiff(baseline: Set<CSSStyleRule>, element: HTMLElement): string {


### PR DESCRIPTION
For whatever reason, it is possible for Safari to get scared of its own `::-webkit-...` rule declarations.

We don't really need any of those, as those pseudo elements aren't going to end up in the final source anyway.

So this patch treats any error when testing selector matches as a non-match.

Fixes #1